### PR TITLE
Remove patternProperties validation

### DIFF
--- a/src/oas/schema/validators.py
+++ b/src/oas/schema/validators.py
@@ -8,6 +8,7 @@ from jsonschema import validators
 
 from ..exceptions import ValidationError
 
+
 _type_draft4_validator = Draft4Validator.VALIDATORS['type']
 
 
@@ -30,9 +31,29 @@ def _enum_validator(validator, enums, instance, schema):
         yield error
 
 
+_additional_properties_draft4_validator = Draft4Validator.VALIDATORS[
+    'additionalProperties'
+]
+
+
+def _additional_properties_validator(validator, aP, instance, schema):
+    schema = {k: v for k, v in schema.items() if k != 'patternProperties'}
+    for error in _additional_properties_draft4_validator(
+        validator, aP, instance, schema
+    ):
+        yield error
+
+
 _Validator = validators.extend(
-    Draft4Validator, {'type': _type_validator, 'enum': _enum_validator}
+    Draft4Validator,
+    {
+        'type': _type_validator,
+        'enum': _enum_validator,
+        'additionalProperties': _additional_properties_validator,
+    },
 )
+
+del _Validator.VALIDATORS['patternProperties']
 
 
 class SchemaValidator(object):

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -156,6 +156,18 @@ def test_unmarshal_object_properties_and_additional_properties(
     assert unmarshaled == expected
 
 
+def test_unmarshal_object_ignore_pattern_properties():
+    schema = {
+        'type': 'object',
+        'patternProperties': {'^[a-z]+$': {'type': 'string'}},
+        'additionalProperties': False,
+    }
+    instance = {'foo': 'bar'}
+
+    unmarshaled = SchemaUnmarshaler()._unmarshal(instance, schema)
+    assert unmarshaled == {}
+
+
 def test_unmarshal_all_of():
     schema = {
         'allOf': [

--- a/tests/schema/test_validators.py
+++ b/tests/schema/test_validators.py
@@ -142,3 +142,19 @@ def test_validate_nullable_with_format(validator):
         validator.validate(instance, schema)
     except ValidationError as e:
         pytest.fail('Unexpected error: {}'.format(e))
+
+
+def test_validate_patternproperties_error(validator):
+    schema = {
+        'type': str('object'),
+        'patternProperties': {'^[a-z]+$': {'type': 'string'}},
+        'additionalProperties': False,
+    }
+    instance = {str('foo1'): 'bar'}
+    message = "Additional properties are not allowed ('foo1' was unexpected)"
+
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate(instance, schema)
+
+    assert len(exc_info.value.errors) == 1
+    assert exc_info.value.errors[0].message == message


### PR DESCRIPTION
Fixes #6.

As it turns out, removing the `patternProperties` validator with `del _Validator.VALIDATORS['patternProperties']` as discussed in #6 is not sufficient. The [`additionalProperties` validator also handles `patternProperties`](https://github.com/Julian/jsonschema/blob/a72332004cdc3ba456de7918bc32059822b2f69a/jsonschema/_validators.py#L44-L55) and calls [`_utils.find_additional_properties`](https://github.com/Julian/jsonschema/blob/a72332004cdc3ba456de7918bc32059822b2f69a/jsonschema/_validators.py#L37) which identifies all properties that are neither specified via `properties` nor match `patternProperties` (see [here](https://github.com/Julian/jsonschema/blob/a72332004cdc3ba456de7918bc32059822b2f69a/jsonschema/_utils.py#L89-L106)).

In addition to removing the `patternProperties` validator, I introduced a custom `additionalProperties` validator which removes `patternProperties` (intentionally without mutating the schema) before passing the schema to the original `additionalProperties` validator.

I've also created a test for the unmarshaler, but I had to use the internal `SchemaUnmarshaler::_unmarshal` method to avoid validating `instance` before unmarshaling which should and does fail for this test pair of `schema` and `instance`. I couldn't find a better way to test the unmarshaler though. What do you think?