### PR TITLE
Unmarshal "allOf" with non-object type sub-schemas

### DIFF
--- a/src/oas/schema/unmarshalers.py
+++ b/src/oas/schema/unmarshalers.py
@@ -66,8 +66,13 @@ class SchemaUnmarshaler(object):
             return handler(self, instance, schema)
 
     def _unmarshal_array(self, instance, schema):
-        # ``items`` MUST be present if the ``type`` is ``array``.
-        return [self._unmarshal(x, schema['items']) for x in instance]
+        # If ``items`` is not present, return the instance without further
+        # unmarshaling.
+        return (
+            [self._unmarshal(x, schema['items']) for x in instance]
+            if 'items' in schema
+            else instance
+        )
 
     def _unmarshal_object(self, instance, schema):
         try:

--- a/src/oas/schema/unmarshalers.py
+++ b/src/oas/schema/unmarshalers.py
@@ -56,12 +56,6 @@ class SchemaUnmarshaler(object):
                         # property, the former result wins.
                         if k not in result or result[k] == instance[k]:
                             result[k] = v
-            # TODO: Handle ``array`` sub-schemas correctly. At this point, an
-            # instance is unmarshaled only based on the first sub-schema. If
-            # ``items`` is NOT present in the first ``array`` sub-schema, then
-            # the array may not be correctly unmarshaled as subsequent
-            # ``array`` sub-schemas, in which ``items`` may be present, are
-            # ignored.
             return result
 
         for sub_schema in schema.get('oneOf') or schema.get('anyOf') or []:

--- a/src/oas/schema/unmarshalers.py
+++ b/src/oas/schema/unmarshalers.py
@@ -3,8 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import Mapping
-
 from six import iteritems
 
 from ..exceptions import ValidationError
@@ -44,9 +42,9 @@ class SchemaUnmarshaler(object):
         if 'allOf' in schema:
             sub_schemas = iter(schema['allOf'])
             result = self._unmarshal(instance, next(sub_schemas))
-            # If the first sub-schema of ``allOf`` unmarshals a ``dict``-like
-            # object, also unmarshal with the remaining sub-schemas.
-            if isinstance(result, Mapping):
+            # If the first sub-schema of ``allOf`` specifies an object, also
+            # unmarshal the remaining sub-schemas and merge the results.
+            if schema['allOf'][0].get('type', 'object') == 'object':
                 for sub_schema in sub_schemas:
                     for k, v in iteritems(
                         self._unmarshal(instance, sub_schema)

--- a/src/oas/schema/unmarshalers.py
+++ b/src/oas/schema/unmarshalers.py
@@ -79,13 +79,8 @@ class SchemaUnmarshaler(object):
             return handler(self, instance, schema)
 
     def _unmarshal_array(self, instance, schema):
-        # If ``items`` is not present, return the instance without further
-        # unmarshaling.
-        return (
-            [self._unmarshal(x, schema['items']) for x in instance]
-            if 'items' in schema
-            else instance
-        )
+        # ``items`` MUST be present if the ``type`` is ``array``.
+        return [self._unmarshal(x, schema['items']) for x in instance]
 
     def _unmarshal_object(self, instance, schema):
         try:

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -204,6 +204,19 @@ def test_unmarshal_all_of_array():
     assert unmarshaled == instance
 
 
+def test_unmarshal_all_of_array_min_items():
+    schema = {
+        'allOf': [
+            {'type': 'array', 'items': {'type': 'number'}},
+            {'type': 'array', 'items': {}, 'minItems': 2},
+        ]
+    }
+    instance = [1]
+    with pytest.raises(ValidationError) as exc_info:
+        SchemaUnmarshaler().unmarshal(instance, schema)
+    assert exc_info.value.errors[0].message == '[1] is too short'
+
+
 @pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
 def test_unmarshal_one_of_or_any_of(schema_type):
     schema = {

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -204,31 +204,6 @@ def test_unmarshal_all_of_array():
     assert unmarshaled == instance
 
 
-def test_unmarshal_all_of_array_without_items_last():
-    schema = {
-        'allOf': [
-            {'type': 'array', 'items': {'type': 'string'}},
-            {'type': 'array', 'minItems': 1},
-        ]
-    }
-    instance = [str('a'), str('b')]
-    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
-    assert unmarshaled == instance
-
-
-@pytest.mark.xfail(reason='not implemented yet')
-def test_unmarshal_all_of_array_without_items_first():
-    schema = {
-        'allOf': [
-            {'type': 'array', 'minItems': 1},
-            {'type': 'array', 'items': {'type': 'string', 'format': 'date'}},
-        ]
-    }
-    instance = [str('2018-01-02')]
-    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
-    assert unmarshaled == [datetime.date(2018, 1, 2)]
-
-
 @pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
 def test_unmarshal_one_of_or_any_of(schema_type):
     schema = {

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -199,6 +199,43 @@ def test_unmarshal_all_of_required_only():
     assert exc_info.value.errors[0].message == "'id' is a required property"
 
 
+def test_unmarshal_all_of_array():
+    schema = {
+        'allOf': [
+            {'type': 'array', 'items': {'type': 'number'}},
+            {'type': 'array', 'items': {'type': 'integer'}},
+        ]
+    }
+    instance = [1, 2]
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+def test_unmarshal_all_of_array_without_items_last():
+    schema = {
+        'allOf': [
+            {'type': 'array', 'items': {'type': 'string'}},
+            {'type': 'array', 'minItems': 1},
+        ]
+    }
+    instance = [str('a'), str('b')]
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+@pytest.mark.xfail(reason='not implemented yet')
+def test_unmarshal_all_of_array_without_items_first():
+    schema = {
+        'allOf': [
+            {'type': 'array', 'minItems': 1},
+            {'type': 'array', 'items': {'type': 'string', 'format': 'date'}},
+        ]
+    }
+    instance = [str('2018-01-02')]
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == [datetime.date(2018, 1, 2)]
+
+
 @pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
 def test_unmarshal_one_of_or_any_of(schema_type):
     schema = {

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -74,13 +74,6 @@ def test_unmarshal_array():
     ]
 
 
-def test_unmarshal_array_without_items():
-    schema = {'type': 'array'}
-    instance = ['2018-01-02', '2018-02-03', '2018-03-04']
-    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
-    assert unmarshaled == instance
-
-
 def test_unmarshal_object():
     schema = {
         'type': 'object',

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -74,6 +74,13 @@ def test_unmarshal_array():
     ]
 
 
+def test_unmarshal_array_without_items():
+    schema = {'type': 'array'}
+    instance = ['2018-01-02', '2018-02-03', '2018-03-04']
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
 def test_unmarshal_object():
     schema = {
         'type': 'object',

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -217,6 +217,34 @@ def test_unmarshal_all_of_array_min_items():
     assert exc_info.value.errors[0].message == '[1] is too short'
 
 
+def test_unmarshal_all_of_primitive_number_integer():
+    schema = {'allOf': [{'type': 'number'}, {'type': 'integer'}]}
+    instance = 1
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+def test_unmarshal_all_of_primitive_string_pattern():
+    schema = {
+        'allOf': [
+            {'type': 'string'},
+            {'type': 'string', 'pattern': '^[a-z]+$'},
+        ]
+    }
+    instance = 'abc'
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+def test_unmarshal_all_of_primitive_string_enum():
+    schema = {
+        'allOf': [{'type': 'string'}, {'type': 'string', 'enum': ['a', 'b']}]
+    }
+    instance = 'a'
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
 @pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
 def test_unmarshal_one_of_or_any_of(schema_type):
     schema = {


### PR DESCRIPTION
This PR adds support for two related aspects of unmarshaling data using an OpenAPI schema:

1. Specifying an array schema _without_ `items` is valid, but `python-oas` currently requires the presence of `items`. This PR returns the raw array instance without further unmarshaling when `items` is not present. Specifying an array schema without `items` can be useful, e.g., for adding constraints such as `{min,max}Items` to another array schema using `allOf`.
1. `python-oas` currently only supports object sub-schemas of `allOf`. This PR adds support for other sub-schemas, in particular array sub-schemas, with the limitation that the first sub-schema is used for unmarshaling. There are a few edge cases where this behavior results in slightly incorrect unmarshaling, e.g. when the first sub-schema is an array schema _without_ `items` and the second sub-schema is an array schema _with_ `items` with date values that should be parsed. The proper solution to this problem is to merge all sub-schemas of `allOf`, but it seems not trivial (see e.g. [`json-schema-merge-allof`](https://github.com/mokkabonna/json-schema-merge-allof)). I couldn't find a Python library for merging OpenAPI schemas, so we would need to write. I think having support for non-object sub-schemas with some limitations is better than not supporting non-object sub-schemas at all for now.