### PR TITLE
Unmarshal "allOf" with "oneOf/anyOf/allOf" sub-schemas

### DIFF
--- a/src/oas/schema/unmarshalers.py
+++ b/src/oas/schema/unmarshalers.py
@@ -42,9 +42,9 @@ class SchemaUnmarshaler(object):
         if 'allOf' in schema:
             sub_schemas = iter(schema['allOf'])
             result = self._unmarshal(instance, next(sub_schemas))
-            # If the first sub-schema of ``allOf`` specifies an object, also
-            # unmarshal the remaining sub-schemas and merge the results.
-            if schema['allOf'][0].get('type', 'object') == 'object':
+            # If ``result`` is a dict, then the sub-schema specify objects, so
+            # also unmarshal the remaining sub-schemas and merge the results.
+            if isinstance(result, dict):
                 for sub_schema in sub_schemas:
                     for k, v in iteritems(
                         self._unmarshal(instance, sub_schema)

--- a/tests/schema/test_unmarshalers.py
+++ b/tests/schema/test_unmarshalers.py
@@ -246,6 +246,36 @@ def test_unmarshal_all_of_primitive_string_enum():
 
 
 @pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
+def test_unmarshal_all_of_one_of_or_any_of(schema_type):
+    schema = {
+        'allOf': [
+            {schema_type: [{'type': 'string'}, {'type': 'number'}]},
+            {'type': 'string'},
+        ]
+    }
+    instance = 'a'
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+def test_unmarshal_all_of_all_of():
+    schema = {
+        'allOf': [
+            {
+                'allOf': [
+                    {'type': 'string'},
+                    {'type': 'string', 'enum': ['a', 'b']},
+                ]
+            },
+            {'type': 'string', 'enum': ['a']},
+        ]
+    }
+    instance = 'a'
+    unmarshaled = SchemaUnmarshaler().unmarshal(instance, schema)
+    assert unmarshaled == instance
+
+
+@pytest.mark.parametrize('schema_type', ['oneOf', 'anyOf'])
 def test_unmarshal_one_of_or_any_of(schema_type):
     schema = {
         schema_type: [


### PR DESCRIPTION
This PR adds support for unmarshaling `allOf` with nested sub-schemas of type `oneOf`/`anyOf`/`allOf`.